### PR TITLE
SLING-13268 - PartialReader section slicing breaks when Reader.skip() returns 0

### DIFF
--- a/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
+++ b/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
@@ -92,20 +92,39 @@ public class PartialReader implements Partial {
             return new BoundedContentReader(r, (long) endCharIndex - startCharIndex);
         }
 
-        /** Skips exactly {@code count} characters from {@code r}. Reader.skip() is allowed to
-         *  skip fewer characters than requested in a single call, so we keep skipping (falling
-         *  back to read() when skip() makes no progress) until the count is reached or EOF hits.
+        /**
+         * Skips up to {@code count} characters from {@code r}.
+         *
+         * This uses Reader.skip() repeatedly. If skip() makes no progress the method falls back
+         * to reading into a temporary buffer (up to 8 KiB) to advance in bulk instead of
+         * degrading to single-character reads. That avoids very slow behavior when skip()
+         * consistently returns 0.
+         *
+         * If EOF is reached before the requested number of characters is skipped the method
+         * returns normally after consuming available input; it does not throw. Callers that
+         * require a strict guarantee that the requested start exists should validate the source
+         * or check the reader state after this call.
          */
         private static void skipFully(Reader r, long count) throws IOException {
             long remaining = count;
+            // start with a buffer sized to the remaining amount but never larger than 8 KiB
+            char[] buf = new char[(int) Math.min(8192L, Math.max(1L, remaining))];
             while (remaining > 0) {
                 final long skipped = r.skip(remaining);
                 if (skipped > 0) {
                     remaining -= skipped;
-                } else if (r.read() == -1) {
-                    break;
+                    // shrink buffer if the remaining amount is smaller than current buffer
+                    if (remaining > 0 && buf.length > remaining) {
+                        buf = new char[(int) Math.min(8192L, remaining)];
+                    }
                 } else {
-                    remaining--;
+                    final int toRead = (int) Math.min((long) buf.length, remaining);
+                    final int n = r.read(buf, 0, toRead);
+                    if (n == -1) {
+                        // EOF reached before skipping everything - stop
+                        break;
+                    }
+                    remaining -= n;
                 }
             }
         }
@@ -118,6 +137,13 @@ public class PartialReader implements Partial {
      *  next one. Extending Reader directly, instead of commons-io's ProxyReader, means the
      *  JDK's own default read()/read(char[]) delegate to read(char[],int,int) below, so
      *  every overload stays bounded no matter which commons-io version is on the classpath.
+     *
+     *  Note: when the underlying reader reaches EOF, reads behave normally and return -1.
+     *  This class does not attempt to recover or throw when the section's start offset was
+     *  beyond EOF; callers that need that guarantee should validate the source beforehand.
+     *  For correctness and performance, this class explicitly implements read(char[],int,int)
+     *  so JDK and commons-io bulk read paths stay bounded; read() and read(char[]) will
+     *  delegate to that implementation.
      */
     private static final class BoundedContentReader extends Reader {
         private final Reader target;

--- a/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
+++ b/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
@@ -89,7 +89,7 @@ public class PartialReader implements Partial {
         public Reader getContent() throws IOException {
             final Reader r = sectionSource.get();
             skipFully(r, startCharIndex);
-            return new BoundedContentReader(r, (long) endCharIndex - startCharIndex);
+            return new BoundedContentReader(r, endCharIndex - startCharIndex);
         }
 
         /**
@@ -105,20 +105,20 @@ public class PartialReader implements Partial {
          * require a strict guarantee that the requested start exists should validate the source
          * or check the reader state after this call.
          */
-        private static void skipFully(Reader r, long count) throws IOException {
-            long remaining = count;
+        private static void skipFully(Reader r, int count) throws IOException {
+            int remaining = count;
             // start with a buffer sized to the remaining amount but never larger than 8 KiB
-            char[] buf = new char[(int) Math.min(8192L, Math.max(1L, remaining))];
+            char[] buf = new char[Math.max(1, Math.min(8192, remaining))];
             while (remaining > 0) {
                 final long skipped = r.skip(remaining);
                 if (skipped > 0) {
-                    remaining -= skipped;
+                    remaining -= (int) skipped;
                     // shrink buffer if the remaining amount is smaller than current buffer
                     if (remaining > 0 && buf.length > remaining) {
-                        buf = new char[(int) Math.min(8192L, remaining)];
+                        buf = new char[Math.min(8192, remaining)];
                     }
                 } else {
-                    final int toRead = (int) Math.min((long) buf.length, remaining);
+                    final int toRead = Math.min(buf.length, remaining);
                     final int n = r.read(buf, 0, toRead);
                     if (n == -1) {
                         // EOF reached before skipping everything - stop
@@ -147,9 +147,9 @@ public class PartialReader implements Partial {
      */
     private static final class BoundedContentReader extends Reader {
         private final Reader target;
-        private long remaining;
+        private int remaining;
 
-        BoundedContentReader(Reader target, long maxChars) {
+        BoundedContentReader(Reader target, int maxChars) {
             this.target = target;
             this.remaining = maxChars;
         }
@@ -159,7 +159,7 @@ public class PartialReader implements Partial {
             if (remaining <= 0) {
                 return -1;
             }
-            final int toRead = (int) Math.min(len, remaining);
+            final int toRead = Math.min(len, remaining);
             final int n = target.read(cbuf, off, toRead);
             if (n > 0) {
                 remaining -= n;

--- a/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
+++ b/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
@@ -35,7 +35,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.BoundedReader;
 import org.jetbrains.annotations.NotNull;
 
 /** Reader for the partials format, which parses a partial file and
@@ -90,7 +89,7 @@ public class PartialReader implements Partial {
         public Reader getContent() throws IOException {
             final Reader r = sectionSource.get();
             skipFully(r, startCharIndex);
-            return new BoundedReader(r, endCharIndex - startCharIndex);
+            return new BoundedContentReader(r, endCharIndex - startCharIndex);
         }
 
         /** Skips exactly {@code count} characters from {@code r}. Reader.skip() is allowed to
@@ -109,6 +108,42 @@ public class PartialReader implements Partial {
                     remaining--;
                 }
             }
+        }
+    }
+
+    /** Bounds reads to at most {@code maxChars} characters.
+     *  commons-io's BoundedReader stopped enforcing this bound on its read(char[]) overload
+     *  in 2.22.0 (only read() and read(char[],int,int) got the fix) - IOUtils.copy() reads
+     *  through exactly that overload, so a section's content would run straight into the
+     *  next one. Extending Reader directly, instead of commons-io's ProxyReader, means the
+     *  JDK's own default read()/read(char[]) delegate to read(char[],int,int) below, so
+     *  every overload stays bounded no matter which commons-io version is on the classpath.
+     */
+    private static final class BoundedContentReader extends Reader {
+        private final Reader target;
+        private long remaining;
+
+        BoundedContentReader(Reader target, long maxChars) {
+            this.target = target;
+            this.remaining = maxChars;
+        }
+
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            if (remaining <= 0) {
+                return -1;
+            }
+            final int toRead = (int) Math.min(len, remaining);
+            final int n = target.read(cbuf, off, toRead);
+            if (n > 0) {
+                remaining -= n;
+            }
+            return n;
+        }
+
+        @Override
+        public void close() throws IOException {
+            target.close();
         }
     }
 

--- a/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
+++ b/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
@@ -89,7 +89,7 @@ public class PartialReader implements Partial {
         public Reader getContent() throws IOException {
             final Reader r = sectionSource.get();
             skipFully(r, startCharIndex);
-            return new BoundedContentReader(r, endCharIndex - startCharIndex);
+            return new BoundedContentReader(r, (long) endCharIndex - startCharIndex);
         }
 
         /** Skips exactly {@code count} characters from {@code r}. Reader.skip() is allowed to

--- a/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
+++ b/src/main/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReader.java
@@ -89,8 +89,26 @@ public class PartialReader implements Partial {
         @Override
         public Reader getContent() throws IOException {
             final Reader r = sectionSource.get();
-            r.skip(startCharIndex);
+            skipFully(r, startCharIndex);
             return new BoundedReader(r, endCharIndex - startCharIndex);
+        }
+
+        /** Skips exactly {@code count} characters from {@code r}. Reader.skip() is allowed to
+         *  skip fewer characters than requested in a single call, so we keep skipping (falling
+         *  back to read() when skip() makes no progress) until the count is reached or EOF hits.
+         */
+        private static void skipFully(Reader r, long count) throws IOException {
+            long remaining = count;
+            while (remaining > 0) {
+                final long skipped = r.skip(remaining);
+                if (skipped > 0) {
+                    remaining -= skipped;
+                } else if (r.read() == -1) {
+                    break;
+                } else {
+                    remaining--;
+                }
+            }
         }
     }
 

--- a/src/test/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReaderTest.java
+++ b/src/test/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReaderTest.java
@@ -216,4 +216,17 @@ public class PartialReaderTest {
             assertEquals("56789", IOUtils.toString(r));
         }
     }
+
+    @Test
+    public void sectionContentStaysBoundedWhenCopiedViaBulkReadCharArray() throws IOException {
+        // IOUtils.copy() reads through read(char[]) - the exact overload commons-io's
+        // BoundedReader stopped bounding in 2.22.0. Section is much shorter than its source,
+        // so this must still stop at the true end no matter which commons-io version is loaded.
+        final String content = "0123456789ABCDEFGHIJ";
+        final Supplier<Reader> source = () -> new StringReader(content);
+        final Partial.Section section = new PartialReader.ParsedSection(source, SectionName.TYPES, "desc", 5, 10);
+        try (Reader r = section.getContent()) {
+            assertEquals("56789", IOUtils.toString(r));
+        }
+    }
 }

--- a/src/test/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReaderTest.java
+++ b/src/test/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReaderTest.java
@@ -218,6 +218,18 @@ public class PartialReaderTest {
     }
 
     @Test
+    public void sectionContentStartBeyondEOFReturnsEmpty() throws IOException {
+        // If the requested start index is beyond the source's length, getContent() should
+        // return an empty reader and not throw.
+        final String content = "0123"; // only 4 chars
+        final Supplier<Reader> source = () -> new StringReader(content);
+        final Partial.Section section = new PartialReader.ParsedSection(source, SectionName.TYPES, "desc", 10, 12);
+        try (Reader r = section.getContent()) {
+            assertEquals("", IOUtils.toString(r));
+        }
+    }
+
+    @Test
     public void sectionContentStaysBoundedWhenCopiedViaBulkReadCharArray() throws IOException {
         // IOUtils.copy() reads through read(char[]) - the exact overload commons-io's
         // BoundedReader stopped bounding in 2.22.0. Section is much shorter than its source,

--- a/src/test/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReaderTest.java
+++ b/src/test/java/org/apache/sling/graphql/schema/aggregator/impl/PartialReaderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.graphql.schema.aggregator.impl;
 
+import java.io.FilterReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -74,6 +75,20 @@ public class PartialReaderTest {
 
     private Supplier<Reader> getStringReaderSupplier(String content) {
         return () -> new StringReader(content);
+    }
+
+    /** Reader wrapper whose skip() always returns 0, as the Reader.skip() contract
+     *  allows, forcing callers to fall back to read()-based skipping.
+     */
+    private static class ZeroSkipReader extends FilterReader {
+        ZeroSkipReader(Reader in) {
+            super(in);
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            return 0;
+        }
     }
 
     @Test
@@ -186,5 +201,19 @@ public class PartialReaderTest {
                 "Expecting the digest to be independent of the source file's line ending style",
                 "SHA-256: 703bd06e9d65118c75abe9a7a06f6a2fcdb8a19ef62d994f4cc1be0b34420383",
                 p.getDigest());
+    }
+
+    @Test
+    public void sectionContentSkipsRobustlyWhenReaderSkipReturnsZero() throws IOException {
+        // Exercise PartialReader.ParsedSection directly: PartialReader's own line-ending
+        // normalization always hands ParsedSection a plain StringReader, which happens to
+        // fully honor skip() in one call and would hide this bug.
+        final String content = "0123456789ABCDEF";
+        final Supplier<Reader> zeroSkipSource = () -> new ZeroSkipReader(new StringReader(content));
+        final Partial.Section section =
+                new PartialReader.ParsedSection(zeroSkipSource, SectionName.TYPES, "desc", 5, 10);
+        try (Reader r = section.getContent()) {
+            assertEquals("56789", IOUtils.toString(r));
+        }
     }
 }


### PR DESCRIPTION
## Summary

`PartialReader.ParsedSection.getContent()` could let one section's content bleed into the next, leaking raw `QUERY:`/`TYPES:` header lines into the aggregated SDL and breaking GraphQL parsing:

1. `reader.skip(startCharIndex)` was called once and assumed to fully advance, but `Reader.skip()` may skip fewer characters than requested.
2. commons-io's `BoundedReader` stopped enforcing its bound on the `read(char[])` overload in 2.22.0 (only `read()` and `read(char[],int,int)` are bounded there) — `IOUtils.copy()` reads through exactly that overload. Confirmed by reproducing against real production schema files: pinning commons-io to 2.22.0 reproduces the exact `SchemaProblem` seen in `GraphQLContentFragmentListIT`.

## Changes

- Added `skipFully()` — retries via `read()` until the offset is reached or EOF.
- Replaced commons-io's `BoundedReader` with a small self-contained `BoundedContentReader` (extends `Reader` directly), so every read overload stays bounded regardless of the commons-io version resolved at runtime.

## Test Plan

- [x] New tests reproduce both issues and pass with the fix
- [x] Full test suite passes
- [x] Verified byte-for-byte against real production schema files with commons-io 2.22.0 pinned

## Links

- JIRA: https://issues.apache.org/jira/browse/SLING-13268

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>